### PR TITLE
Slow heroku dyno need a long keep-alive config for gunicorn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,4 @@ clean-pyc:
 
 deploy:
 	./decrypt.sh
-	gunicorn app:app
+	gunicorn app:app --keep-alive 6


### PR DESCRIPTION
heroku网络太慢了＝ ＝然后那个list太长。。。keep alive需要长一点
